### PR TITLE
feat: RSA 2026 master redbook + field note templates

### DIFF
--- a/docs/field-notes/day1-notes.md
+++ b/docs/field-notes/day1-notes.md
@@ -1,0 +1,63 @@
+# RSA 2026 — Day 1 Field Notes
+**Date:** Monday, March 23, 2026
+**Focus:** Registration + Keynotes + North Hall big vendors
+
+---
+
+## Keynote Takeaways
+
+| Speaker | Company | Key Takeaway |
+|---------|---------|--------------|
+| | | |
+| | | |
+
+---
+
+## Booth Visits
+
+### [Company Name] — Booth [Number]
+**Problem:**
+**Demo seen:**
+**Differentiator:**
+**Pricing/model:**
+**Follow-up:**
+- [ ]
+
+---
+
+### [Company Name] — Booth [Number]
+**Problem:**
+**Demo seen:**
+**Differentiator:**
+**Pricing/model:**
+**Follow-up:**
+- [ ]
+
+---
+
+## Conversations / Hallway Insights
+
+-
+
+---
+
+## CyBEER Ops Reception Notes
+*(All Access/Expo Plus pass required — Tuesday evening)*
+
+-
+
+---
+
+## Photos Taken Today
+> Run: `python scripts/photo-ingest.py docs/field-notes/photos/day1/`
+
+| File | Vendor | Notes |
+|------|--------|-------|
+| | | |
+
+---
+
+## Tomorrow's Priority List (Day 2)
+- [ ]
+- [ ]
+- [ ]

--- a/docs/field-notes/day2-notes.md
+++ b/docs/field-notes/day2-notes.md
@@ -1,0 +1,54 @@
+# RSA 2026 — Day 2 Field Notes
+**Date:** Tuesday, March 24, 2026
+**Focus:** Full expo + Innovation Sandbox finals + sessions
+
+---
+
+## Sessions Attended
+
+| Time | Session Title | Speaker | Key Takeaway |
+|------|--------------|---------|--------------|
+| | | | |
+
+---
+
+## Booth Visits
+
+### [Company Name] — Booth [Number]
+**Problem:**
+**Demo seen:**
+**Differentiator:**
+**Pricing/model:**
+**Follow-up:**
+- [ ]
+
+---
+
+## Innovation Sandbox Finalists Observed
+
+| Company | Category | Pitch Summary | Score (1-5) |
+|---------|----------|---------------|-------------|
+| Geordie AI | AI Security | | |
+| | | | |
+
+---
+
+## Conversations / Hallway Insights
+
+-
+
+---
+
+## Photos Taken Today
+> Run: `python scripts/photo-ingest.py docs/field-notes/photos/day2/`
+
+| File | Vendor | Notes |
+|------|--------|-------|
+| | | |
+
+---
+
+## Tomorrow's Priority List (Day 3 — ESE Opens)
+- [ ] Walk full Early Stage Expo floor
+- [ ] Hit RSAC Next Stage
+- [ ]

--- a/docs/field-notes/day3-notes.md
+++ b/docs/field-notes/day3-notes.md
@@ -1,0 +1,61 @@
+# RSA 2026 — Day 3 Field Notes
+**Date:** Wednesday, March 25, 2026
+**Focus:** Early Stage Expo (general access opens today) + RSAC Next Stage
+
+---
+
+## Early Stage Expo Sweep
+
+| Kiosk | Company | Problem | Score (1-5) | Follow-up? |
+|-------|---------|---------|-------------|------------|
+| ESE-09 | Unbound AI | | | |
+| ESE-11 | 12Port | | | |
+| ESE-19 | Cline | | | |
+| ESE-28 | MyCISO | | | |
+| | | | | |
+| | | | | |
+| | | | | |
+
+---
+
+## RSAC Next Stage Companies
+
+| Company | Pitch | Interesting? |
+|---------|-------|-------------|
+| | | |
+
+---
+
+## Booth Visits
+
+### [Company Name] — Booth [Number]
+**Problem:**
+**Demo seen:**
+**Differentiator:**
+**Pricing/model:**
+**Follow-up:**
+- [ ]
+
+---
+
+## Sessions Attended
+
+| Time | Session Title | Speaker | Key Takeaway |
+|------|--------------|---------|--------------|
+| | | | |
+
+---
+
+## Photos Taken Today
+> Run: `python scripts/photo-ingest.py docs/field-notes/photos/day3/`
+
+| File | Vendor | Notes |
+|------|--------|-------|
+| | | |
+
+---
+
+## Tomorrow's Priority (Day 4 — Last Day)
+- [ ] Follow up with shortlisted vendors
+- [ ] Attend closing ceremony
+- [ ] Hugh Jackman closing celebration (Thursday)

--- a/docs/field-notes/day4-notes.md
+++ b/docs/field-notes/day4-notes.md
@@ -1,0 +1,62 @@
+# RSA 2026 — Day 4 Field Notes
+**Date:** Thursday, March 26, 2026
+**Focus:** Final follow-ups + closing ceremony + Hugh Jackman celebration
+
+---
+
+## Final Booth Follow-Ups
+
+| Vendor | Booth | What to Discuss | Done? |
+|--------|-------|-----------------|-------|
+| | | | |
+| | | | |
+
+---
+
+## Sessions Attended
+
+| Time | Session Title | Speaker | Key Takeaway |
+|------|--------------|---------|--------------|
+| | | | |
+
+---
+
+## Closing Ceremony Notes
+
+-
+
+---
+
+## Photos Taken Today
+> Run: `python scripts/photo-ingest.py docs/field-notes/photos/day4/`
+
+| File | Vendor | Notes |
+|------|--------|-------|
+| | | |
+
+---
+
+## Post-Conference Action Items
+
+| Action | Vendor | Owner | Due |
+|--------|--------|-------|-----|
+| | | | |
+| | | | |
+
+---
+
+## Top 5 Vendors to Follow Up With
+
+1. **[Vendor]** — [Why]
+2. **[Vendor]** — [Why]
+3. **[Vendor]** — [Why]
+4. **[Vendor]** — [Why]
+5. **[Vendor]** — [Why]
+
+---
+
+## Overall Conference Themes (CrispAI Takeaways)
+
+1.
+2.
+3.

--- a/docs/field-notes/photo-log.md
+++ b/docs/field-notes/photo-log.md
@@ -1,0 +1,35 @@
+# RSA 2026 — Photo Log
+
+Track all booth photos here. Run `python scripts/photo-ingest.py <photo>` to auto-analyze and append to this log.
+
+---
+
+## Day 1 — Monday, March 23
+
+| # | File | Vendor | Booth | Auto-Analysis | Notes |
+|---|------|--------|-------|---------------|-------|
+| 1 | | | | | |
+
+---
+
+## Day 2 — Tuesday, March 24
+
+| # | File | Vendor | Booth | Auto-Analysis | Notes |
+|---|------|--------|-------|---------------|-------|
+| 1 | | | | | |
+
+---
+
+## Day 3 — Wednesday, March 25 (ESE opens)
+
+| # | File | Vendor | Booth | Auto-Analysis | Notes |
+|---|------|--------|-------|---------------|-------|
+| 1 | | | | | |
+
+---
+
+## Day 4 — Thursday, March 26
+
+| # | File | Vendor | Booth | Auto-Analysis | Notes |
+|---|------|--------|-------|---------------|-------|
+| 1 | | | | | |

--- a/docs/redbook/rsa_redbook.md
+++ b/docs/redbook/rsa_redbook.md
@@ -1,0 +1,174 @@
+# RSA Conference 2026 Redbook
+## CrispAI — Field Guide & Vendor Reference
+
+**Prepared by:** CrispAI
+**Event Dates:** Monday–Thursday, March 23–26, 2026
+**Version:** 1.0
+
+---
+
+# Part 1 — Event Overview
+
+| Field | Details |
+|-------|---------|
+| **Event** | RSA Conference 2026 (35th Annual) |
+| **Dates** | March 23–26, 2026 |
+| **Venue** | Moscone Center, San Francisco |
+| **Address** | 747 Howard Street, San Francisco, CA 94103 |
+| **Attendance** | 45,000+ from 130+ countries |
+| **Exhibitors** | 1,814 companies |
+| **Sessions** | 570+ across 31 tracks |
+| **Official Site** | https://www.rsaconference.com/usa |
+| **Exhibitor Directory** | https://path.rsaconference.com/flow/rsac/us26/exhibitors/page/exhibitors |
+
+---
+
+# Part 2 — Moscone Center Floor Map
+
+## Hall Layout
+
+| Hall | Location | Size | Notes |
+|------|----------|------|-------|
+| **Hall A** | Moscone North/South — Exhibit Level | 86,204 sq ft | Column-free, 37' ceilings |
+| **Hall B** | Moscone North/South — Exhibit Level | 50,787 sq ft | Column-free |
+| **Hall C** | Moscone North/South — Exhibit Level | 107,392 sq ft | Largest hall |
+| **Hall D** | Moscone North/South — Exhibit Level | 56,992 sq ft | 24–18' ceilings |
+| **Hall E** | Moscone North/South — Exhibit Level | 41,812 sq ft | 24' ceilings |
+| **Hall F** | Moscone North/South — Exhibit Level | 138,631 sq ft | 28' ceilings, 744 booths |
+| **West Hall L1** | Moscone West — Level 1 | 96,660 sq ft | 27' ceilings, up to 500 booths |
+
+## Booth Numbering
+- **North Hall booths:** prefix `N-` (e.g., N-5845)
+- **South Hall booths:** prefix `S-` (e.g., S-3316)
+- **Early Stage Expo kiosks:** prefix `ESE-` (e.g., ESE-19)
+- **Standard numeric:** no prefix (e.g., Booth 327)
+
+## Known Booth Locations
+
+| Vendor | Booth | Hall |
+|--------|-------|------|
+| Cisco | 6044 | North |
+| Splunk (Cisco) | N-6144 | North |
+| CrowdStrike | N-5845 | North |
+| Microsoft Security | N-5744 | North |
+| Fortinet | N-5762 | North |
+| Proofpoint | N-6163 | North |
+| Mimecast | N-5245 | North |
+| GlobalSign by GMO | N-5181 | North |
+| Stellar Cyber | 327 | South |
+| Apiiro | S-3316 | South |
+| Teleport | S-3111 | South |
+| IDEMIA | S-2452 | South |
+| Novee | S-0262 | South |
+| Halcyon | 4315 | — |
+| NetApp | 2439 | — |
+| Cline | ESE-19 | Early Stage |
+| MyCISO | ESE-28 | Early Stage |
+| Unbound AI | ESE-09 | Early Stage |
+| 12Port | ESE-11 | Early Stage |
+
+> **Note:** Palo Alto Networks is not exhibiting at RSAC 2026 (second consecutive year).
+
+---
+
+# Part 3 — Conference Schedule
+
+| Day | Date | Key Events |
+|-----|------|-----------|
+| **Day 1** | Mon, March 23 | Registration opens; Keynotes; Expo opens; CyBEER Ops Reception (All Access/Expo Plus pass) |
+| **Day 2** | Tue, March 24 | Full expo day; Sessions; Innovation Sandbox finals |
+| **Day 3** | Wed, March 25 | Full expo day; Early Stage Expo general access opens; RSAC Next Stage |
+| **Day 4** | Thu, March 26 | Final expo day; Closing ceremony; Hugh Jackman closing celebration |
+
+---
+
+# Part 4 — Sponsor Tiers
+
+## Diamond Sponsors
+Cisco · CrowdStrike · Microsoft Security · Teramind · Ubiquiti
+
+## Platinum Sponsors
+Armis · Axonius · Check Point · Cloudflare · ExtraHop · Fortinet · Google Cloud Security · IBM Security · Illumio · Rubrik · SentinelOne · Splunk · Tenable · Varonis
+
+## Gold Sponsors
+Akamai · AT&T Business · Broadcom · Commvault · Elastic · Entrust · ESET · Exabeam · Expel · Island · ManageEngine · Mimecast · Okta · OpenText · Snyk · ThreatLocker · Veeam · Wiz · Zscaler
+
+---
+
+# Part 5 — Innovation Sandbox & Early Stage
+
+## Innovation Sandbox
+- **Format:** Top 10 finalist startups compete; each receives $5M investment opportunity
+- **RSAC Most Innovative Startup 2026:** Geordie AI
+
+## Early Stage Expo (ESE)
+- ~80 kiosks featuring emerging startups
+- **RSAC Next Stage:** 10 rapidly growing companies
+- Notable ESE kiosks: Cline (ESE-19), MyCISO (ESE-28), Unbound AI (ESE-09), 12Port (ESE-11)
+
+---
+
+# Part 6 — 24 Vendor Clusters at a Glance
+
+| # | Cluster | Doc |
+|---|---------|-----|
+| 01 | Identity & Access Management | `clusters/01-identity-iam.md` |
+| 02 | Zero Trust Architecture | `clusters/02-zero-trust.md` |
+| 03 | Cloud Security (CNAPP/CSPM) | `clusters/03-cloud-security.md` |
+| 04 | Endpoint / EDR / XDR | `clusters/04-endpoint-edr-xdr.md` |
+| 05 | SIEM & Log Management | `clusters/05-siem-log-mgmt.md` |
+| 06 | SOAR & Automation | `clusters/06-soar-automation.md` |
+| 07 | Network Security & NDR | `clusters/07-network-ndr.md` |
+| 08 | SASE / SSE | `clusters/08-sase-sse.md` |
+| 09 | Threat Intelligence | `clusters/09-threat-intelligence.md` |
+| 10 | Vulnerability Management | `clusters/10-vuln-mgmt.md` |
+| 11 | AppSec / DevSecOps | `clusters/11-appsec-devsecops.md` |
+| 12 | API Security | `clusters/12-api-security.md` |
+| 13 | Data Security & Privacy | `clusters/13-data-security.md` |
+| 14 | Email & Messaging Security | `clusters/14-email-security.md` |
+| 15 | OT / ICS / IoT Security | `clusters/15-ot-ics-iot.md` |
+| 16 | Fraud & Financial Security | `clusters/16-fraud-financial.md` |
+| 17 | Risk / GRC / Compliance | `clusters/17-risk-grc.md` |
+| 18 | Managed Security (MSSP) | `clusters/18-mssp.md` |
+| 19 | Security Awareness & Training | `clusters/19-security-training.md` |
+| 20 | Incident Response & Forensics | `clusters/20-ir-forensics.md` |
+| 21 | Passwordless / MFA | `clusters/21-passwordless-mfa.md` |
+| 22 | AI / ML Security | `clusters/22-ai-ml-security.md` |
+| 23 | Container & Cloud-Native | `clusters/23-container-cloud-native.md` |
+| 24 | Early Stage / Innovation Sandbox | `clusters/24-early-stage.md` |
+
+---
+
+# Part 7 — CrispAI Quick Reference
+
+## Arriving Checklist
+- [ ] Pick up badge at registration (Moscone Center, 747 Howard St)
+- [ ] Download offline redbook: `./scripts/crisp-rsa`
+- [ ] Check Innovation Sandbox schedule
+- [ ] Prioritize North Hall big vendors (Cisco 6044, CrowdStrike N-5845, Microsoft N-5744)
+- [ ] Hit Early Stage Expo on Day 3 (general access opens Wed March 25)
+- [ ] Attend closing celebration — Hugh Jackman (Thursday March 26)
+
+## Key Contacts
+| Purpose | Contact |
+|---------|---------|
+| RSAC General | https://www.rsaconference.com/usa |
+| Exhibitor Directory | https://path.rsaconference.com/flow/rsac/us26/exhibitors/page/exhibitors |
+| Moscone Center | Events@moscone.com · 415.974.4000 |
+| Floor Plans | https://www.moscone.com/floorplans |
+
+## Photo Capture Workflow (Offline)
+```bash
+# Convert iPhone HEIC photos
+bash scripts/convert-photos.sh ~/Desktop/RSA-Day1/
+
+# Analyze a booth photo with local LLM
+python scripts/photo-ingest.py photo.jpg
+
+# Chat with redbook offline
+./scripts/crisp-rsa "Which booths are in the Early Stage Expo?"
+```
+
+---
+
+*CrispAI — RSA Conference 2026 Redbook v1.0 — March 23–26, 2026*


### PR DESCRIPTION
## Summary
- Master redbook `docs/redbook/rsa_redbook.md` — event overview, Moscone floor map, known booth locations for 19 vendors, sponsor tiers, Innovation Sandbox details
- Per-day field note templates (Day 1–4) with structured capture format
- Photo log template pre-linked to `photo-ingest.py` pipeline

## Highlights
- Conference is live **March 23–26, 2026** at Moscone Center (747 Howard St, SF)
- Booth numbering guide: N- (North), S- (South), ESE- (Early Stage Expo)
- Closing celebration: **Hugh Jackman** on Thursday March 26
- Palo Alto Networks is **not exhibiting** this year (second consecutive)

## Test plan
- [ ] Review `docs/redbook/rsa_redbook.md` for accuracy against official RSAC site
- [ ] Verify booth numbers against badge/floor map on arrival
- [ ] Fill in daily field note templates during conference

🤖 Generated with [Claude Code](https://claude.com/claude-code)